### PR TITLE
Fix rendering bug caused by mime-type and update styles

### DIFF
--- a/packages/react/src/components/Media.tsx
+++ b/packages/react/src/components/Media.tsx
@@ -16,9 +16,16 @@ function Text({ media }: { media: string }) {
   )
 }
 
-function Video({ media }: { media: string }) {
+function Video({ media, autoPlay }: { media: string; autoPlay: boolean }) {
   return (
-    <video className="nfte__media-content" muted autoPlay loop playsInline>
+    <video
+      className="nfte__media-content"
+      muted
+      autoPlay={autoPlay}
+      controls={!autoPlay}
+      loop
+      playsInline
+    >
       <source src={media} />
     </video>
   )
@@ -28,20 +35,21 @@ function Audio({ media }: { media: string }) {
   return <audio className="nfte__media-content" controls src={media}></audio>
 }
 
-export default function Media({ media }: { media: string }) {
-  const [mimeType, setMimeType] = useState<string | null>(null)
+export default function Media({
+  media,
+  mediaMimeType,
+  autoPlay,
+}: {
+  media: string
+  mediaMimeType: string
+  autoPlay: boolean
+}) {
+  if (mediaMimeType?.includes("text")) return <Text media={media} />
 
-  useEffect(() => {
-    fetch(media, { method: "HEAD" }).then((r) =>
-      setMimeType(r.headers.get("Content-Type"))
-    )
-  }, [])
+  if (mediaMimeType?.includes("video"))
+    return <Video media={media} autoPlay={autoPlay} />
 
-  if (mimeType?.includes("text")) return <Text media={media} />
-
-  if (mimeType?.includes("video")) return <Video media={media} />
-
-  if (mimeType?.includes("audio")) return <Audio media={media} />
+  if (mediaMimeType?.includes("audio")) return <Audio media={media} />
 
   return <img className="nfte__media-content" src={media} />
 }

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -25,12 +25,14 @@ function NFT({
     platformUrl,
     mediaUrl,
     mediaPageUrl,
+    mediaMimeType,
     blockNumber,
     timestamp,
   },
   className,
   style,
   darkMode,
+  autoPlay,
 }: NFTEProps) {
   return (
     <div
@@ -60,9 +62,13 @@ function NFT({
         </div>
       </section>
 
-      {mediaUrl && (
+      {mediaUrl && mediaMimeType && (
         <section className="nfte__media">
-          <Media media={mediaUrl} />
+          <Media
+            media={mediaUrl}
+            mediaMimeType={mediaMimeType}
+            autoPlay={autoPlay}
+          />
         </section>
       )}
 
@@ -113,6 +119,7 @@ export function NFTE({
   className,
   style,
   darkMode,
+  autoPlay = true,
 }: {
   contract: string
   tokenId: string
@@ -120,6 +127,7 @@ export function NFTE({
   className?: string
   style?: CSSProperties
   darkMode?: boolean
+  autoPlay: boolean
 }) {
   useStyleSheet(styles)
 
@@ -145,6 +153,12 @@ export function NFTE({
   if (!data) return <Loading style={style} />
 
   return (
-    <NFT data={data} className={className} style={style} darkMode={darkMode} />
+    <NFT
+      data={data}
+      className={className}
+      style={style}
+      darkMode={darkMode}
+      autoPlay={autoPlay}
+    />
   )
 }

--- a/packages/react/src/styles.css
+++ b/packages/react/src/styles.css
@@ -97,7 +97,7 @@
 .nfte--loaded .nfte__label {
   color: var(--nfte-colors-text-light);
   text-decoration: none;
-  margin-bottom: var(--nfte-space1);
+  margin-bottom: 4px;
 }
 
 .nfte--loaded .nfte__creator-id {
@@ -121,7 +121,7 @@
   background-color: #000;
   margin-bottom: var(--nfte-space-1);
   aspect-ratio: 1/1;
-  height: 480px;
+  max-height: 480px;
 }
 
 .nfte--loaded .nfte__media-content {

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -14,6 +14,7 @@ export type NFTData = {
   platformUrl: string
   mediaUrl: string
   mediaPageUrl: string
+  mediaMimeType?: string
   blockNumber: string
   timestamp: string
   // Deprecated
@@ -27,4 +28,5 @@ export type NFTEProps = {
   className?: string
   style?: CSSProperties
   darkMode?: boolean
+  autoPlay: boolean
 }

--- a/packages/site/knownContracts/ethBlockArt.js
+++ b/packages/site/knownContracts/ethBlockArt.js
@@ -1,4 +1,5 @@
 import { BigNumber } from "ethers"
+import getMimeType from "@utils/getMimeType"
 
 export default {
   addresses: ["0xb80fBF6cdb49c33dC6aE4cA11aF8Ac47b0b4C0f3"],
@@ -25,6 +26,8 @@ export default {
     const metadataRes = await fetch(tokenURI.value)
     const metadata = await metadataRes.json()
 
+    const mediaMimeType = await getMimeType(metadata?.image)
+
     return {
       metadata,
       name: metadata?.name,
@@ -35,6 +38,7 @@ export default {
       creatorOfUrl: null,
       mediaUrl: metadata?.image,
       mediaPageUrl: `https://ethblock.art/view/${tokenId}`,
+      mediaMimeType,
       platform: "EthBlock.art",
       platformUrl: "https://ethblock.art",
       blockNumber,

--- a/packages/site/knownContracts/foundation.js
+++ b/packages/site/knownContracts/foundation.js
@@ -1,6 +1,7 @@
 import { BigNumber } from "ethers"
-import isIPFS from "utils/isIPFS"
-import makeIPFSUrl from "utils/makeIPFSUrl"
+import isIPFS from "@utils/isIPFS"
+import makeIPFSUrl from "@utils/makeIPFSUrl"
+import getMimeType from "@utils/getMimeType"
 
 export default {
   addresses: ["0x3B3ee1931Dc30C1957379FAc9aba94D1C48a5405"],
@@ -32,6 +33,8 @@ export default {
       ? makeIPFSUrl(metadata?.image)
       : metadata?.image
 
+    const mediaMimeType = await getMimeType(mediaUrl)
+
     return {
       metadata,
       name: metadata?.name,
@@ -42,6 +45,7 @@ export default {
       creatorOfUrl: null,
       mediaUrl,
       mediaPageUrl: null,
+      mediaMimeType,
       platform: "Foundation",
       platformUrl: "https://foundation.app",
       blockNumber,

--- a/packages/site/knownContracts/rarible.js
+++ b/packages/site/knownContracts/rarible.js
@@ -1,6 +1,7 @@
 import { BigNumber } from "ethers"
 import isIPFS from "@utils/isIPFS"
 import makeIPFSUrl from "@utils/makeIPFSUrl"
+import getMimeType from "@utils/getMimeType"
 
 export default {
   addresses: ["0x60f80121c31a0d46b5279700f9df786054aa5ee5"],
@@ -34,6 +35,8 @@ export default {
       ? makeIPFSUrl(metadata?.image)
       : metadata?.image
 
+    const mediaMimeType = await getMimeType(mediaUrl)
+
     return {
       metadata,
       name: metadata?.name,
@@ -44,6 +47,7 @@ export default {
       creatorOfUrl: `https://app.rarible.com/user/${creatorOf}`,
       mediaUrl: mediaUrl,
       mediaPageUrl: `https://app.rarible.com/token/${contractAddress}:${tokenId}`,
+      mediaMimeType,
       platform: "Rarible",
       platformUrl: "https://rarible.com",
       blockNumber,

--- a/packages/site/knownContracts/superrare.js
+++ b/packages/site/knownContracts/superrare.js
@@ -1,5 +1,6 @@
 import kebabCase from "lodash/kebabCase"
 import { BigNumber } from "ethers"
+import getMimeType from "@utils/getMimeType"
 
 export default {
   addresses: ["0xb932a70a57673d89f4acffbe830e8ed7f75fb9e0"],
@@ -31,6 +32,8 @@ export default {
     const metadataRes = await fetch(tokenURI.value)
     const metadata = await metadataRes.json()
 
+    const mediaMimeType = await getMimeType(metadata?.media?.uri)
+
     return {
       metadata,
       name: metadata?.name,
@@ -43,6 +46,7 @@ export default {
       mediaPageUrl: `https://superrare.co/artwork-v2/${kebabCase(
         metadata.name
       )}-${tokenId}`,
+      mediaMimeType,
       platform: "SuperRare",
       platformUrl: "https://superrare.co",
       blockNumber,

--- a/packages/site/knownContracts/zora.js
+++ b/packages/site/knownContracts/zora.js
@@ -40,6 +40,7 @@ export default {
       creatorOfUrl: `https://zora.co/${creatorOf}`,
       mediaUrl: tokenURI.value,
       mediaPageUrl: `https://zora.co/${creatorOf}/${tokenId}`,
+      mediaMimeType: metadata.mimeType,
       platform: "Zora",
       platformUrl: "https://zora.co",
       blockNumber,

--- a/packages/site/pages/docs.js
+++ b/packages/site/pages/docs.js
@@ -135,6 +135,10 @@ export default function Docs() {
             <InlineCode>?darkMode=0</InlineCode> - Enables dark mode for the
             embed
           </Box>
+          <Box as="p">
+            <InlineCode>?disableAutoPlay=0</InlineCode> - Disables autoplaying
+            of video files
+          </Box>
         </Box>
 
         <Box css={{ mb: "@4" }}>
@@ -160,6 +164,11 @@ export default function Docs() {
           <Box as="p">
             <InlineCode>style</InlineCode> <strong>Object</strong> - Inline
             styles that are applied to the top level wrapper element
+          </Box>
+          <Box as="p">
+            <InlineCode>autoPlay</InlineCode> <strong>Boolean</strong> - If set
+            to false will disable autoplaying of videos. Default:{" "}
+            <InlineCode>true</InlineCode>
           </Box>
         </Box>
 
@@ -571,6 +580,12 @@ export default function Docs() {
         <Box as="p" css={{ m: 0, mb: "@3" }}>
           <InlineCode>mediaPageUrl</InlineCode> - The url of the media files
           page on the platform
+        </Box>
+
+        <Box as="p" css={{ m: 0, mb: "@3" }}>
+          <InlineCode>mediaMimeType</InlineCode> - The mime type of the media
+          file e.g. <InlineCode>video/mp4</InlineCode>,{" "}
+          <InlineCode>image/png</InlineCode>
         </Box>
 
         <Box as="p" css={{ m: 0, mb: "@3" }}>

--- a/packages/site/pages/docs.js
+++ b/packages/site/pages/docs.js
@@ -447,9 +447,6 @@ export default function Docs() {
           <strong>Currently supported</strong>
           <Box as="ul" css={{ pl: "@3", mb: "@4", mt: "@1" }}>
             <Box as="li" css={{ mb: "@1" }}>
-              Async Art
-            </Box>
-            <Box as="li" css={{ mb: "@1" }}>
               EthBlock.art
             </Box>
             <Box as="li" css={{ mb: "@1" }}>

--- a/packages/site/pages/index.js
+++ b/packages/site/pages/index.js
@@ -1,5 +1,6 @@
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { useDebounce } from "use-debounce"
+import { useRouter } from "next/router"
 import Link from "next/link"
 import Head from "next/head"
 import sample from "lodash/sample"
@@ -12,11 +13,22 @@ import { NFTE } from "@nfte/react"
 import previewNFTs from "utils/previewNFTs"
 
 export default function Home() {
-  const [randomNFT, setRandomNFT] = useState(sample(previewNFTs))
+  const router = useRouter()
   const [contract, setContract] = useState("")
   const [tokenId, setTokenId] = useState("")
   const [debouncedContract] = useDebounce(contract, 1000)
   const [debouncedTokenId] = useDebounce(tokenId, 1000)
+
+  useEffect(() => {
+    if (router.isReady && router.query?.contract && router.query?.tokenId) {
+      setContract(router.query?.contract)
+      setTokenId(router.query?.tokenId)
+    } else {
+      const rNFT = sample(previewNFTs)
+      setContract(rNFT.contract)
+      setTokenId(rNFT.tokenId)
+    }
+  }, [router])
 
   return (
     <>
@@ -126,7 +138,6 @@ export default function Home() {
         <Box
           css={{
             display: "flex",
-
             justifyContent: "center",
             flexWrap: "wrap",
           }}
@@ -153,6 +164,7 @@ export default function Home() {
                 px: "@1",
                 py: "@0",
               }}
+              name="contract"
               placeholder="0x...."
               value={contract}
               onChange={(e) => setContract(e.target.value)}
@@ -181,6 +193,7 @@ export default function Home() {
                 px: "@1",
                 py: "@0",
               }}
+              name="tokenId"
               placeholder="1"
               value={tokenId}
               onChange={(e) => setTokenId(e.target.value)}
@@ -205,7 +218,12 @@ export default function Home() {
               mb: "@3",
               cursor: "pointer",
             }}
-            onClick={() => setRandomNFT(sample(previewNFTs))}
+            onClick={() => {
+              const rNFT = sample(previewNFTs)
+              console.log(rNFT)
+              setContract(rNFT.contract)
+              setTokenId(rNFT.tokenId)
+            }}
           >
             Get random NFT
           </Box>
@@ -213,16 +231,8 @@ export default function Home() {
 
         <Box css={{ mb: "@4" }}>
           <NFTE
-            contract={
-              debouncedContract.length === 0
-                ? randomNFT.contract
-                : debouncedContract
-            }
-            tokenId={
-              debouncedTokenId.length === 0
-                ? randomNFT.tokenId
-                : debouncedTokenId
-            }
+            contract={debouncedContract}
+            tokenId={debouncedTokenId}
             style={{ marginLeft: "auto", marginRight: "auto" }}
           />
         </Box>

--- a/packages/site/public/embed.html
+++ b/packages/site/public/embed.html
@@ -11,5 +11,13 @@
       async
       src="http://localhost:3000/api/embed.js?contract=0xb932a70a57673d89f4acffbe830e8ed7f75fb9e0&tokenId=10243"
     ></script>
+
+    <hr />
+
+    <div className="nft-embed"></div>
+    <script
+      async
+      src="http://localhost:3000/api/embed.js?contract=0xb932a70a57673d89f4acffbe830e8ed7f75fb9e0&tokenId=14316"
+    ></script>
   </body>
 </html>

--- a/packages/site/utils/getMimeType.js
+++ b/packages/site/utils/getMimeType.js
@@ -1,0 +1,4 @@
+export default async function getMimeType(mediaUrl) {
+  const res = await fetch(mediaUrl, { method: "HEAD" })
+  return res.headers.get("Content-Type")
+}

--- a/packages/site/utils/getNFTData.js
+++ b/packages/site/utils/getNFTData.js
@@ -1,11 +1,10 @@
 import { ethers, BigNumber, utils } from "ethers"
-import { fromUnixTime, format } from "date-fns"
-import { zonedTimeToUtc } from "date-fns-tz"
 import has from "lodash/has"
 import knownContracts from "knownContracts"
 import erc721ABI from "abis/erc721"
 import isIPFS from "@utils/isIPFS"
 import makeIPFSUrl from "@utils/makeIPFSUrl"
+import getMimeType from "@utils/getMimeType"
 
 const provider = new ethers.providers.CloudflareProvider()
 const historicalProvider = new ethers.providers.InfuraProvider(
@@ -55,6 +54,8 @@ async function defaultGetContractData({
     ? makeIPFSUrl(metadata?.image)
     : metadata?.image
 
+  const mediaMimeType = await getMimeType(mediaUrl)
+
   return {
     metadata,
     name: metadata?.name,
@@ -65,6 +66,7 @@ async function defaultGetContractData({
     creatorOfUrl: null,
     mediaUrl,
     mediaPageUrl: null,
+    mediaMimeType: mediaMimeType,
     platform: null,
     platformUrl: null,
     blockNumber,
@@ -108,6 +110,7 @@ export default async function ({ contract, tokenId }) {
       creatorOfUrl,
       mediaUrl,
       mediaPageUrl,
+      mediaMimeType,
       platform,
       platformUrl,
       blockNumber,
@@ -148,6 +151,7 @@ export default async function ({ contract, tokenId }) {
       platformUrl: resolvedPlatformUrl,
       mediaUrl,
       mediaPageUrl: resolvedMediaPageUrl,
+      mediaMimeType,
       blockNumber,
       timestamp,
       // deprecated

--- a/packages/site/utils/previewNFTs.js
+++ b/packages/site/utils/previewNFTs.js
@@ -5,6 +5,8 @@ export default [
   { contract: "0xb932a70a57673d89f4acffbe830e8ed7f75fb9e0", tokenId: "18552" },
   // Jeff Kraus (Foundation)
   { contract: "0x3b3ee1931dc30c1957379fac9aba94d1c48a5405", tokenId: "15" },
+  // Sam Mason de Caires (Foundation)
+  { contract: "0x3b3ee1931dc30c1957379fac9aba94d1c48a5405", tokenId: "214" },
   // EthBlock.art
   { contract: "0xb80fbf6cdb49c33dc6ae4ca11af8ac47b0b4c0f3", tokenId: "149" },
   // Zora


### PR DESCRIPTION
This will fix a bug with incorrect rendering of anything other than images on browsers other than latest safari, this also moves the mimetype fetching to the api layer to make life slightly easier for all consumers.

Also fixed a couple fo style causing issues with rendering on small screens and a typo on a css variable.

Adds autoplay disabling for the react component and script embed as for people rendering lots of video NFT's it was causing some issues