### PR TITLE
Release v1.0.3

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.2",
+  "version": "1.0.3",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/handler/package.json
+++ b/packages/handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nfte/handler",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A function to allow you to self-host the api portion of NFTE in your own infrastructure.",
   "source": "src/index.js",
   "main": "dist/handler.js",

--- a/packages/handler/src/knownContracts/foundation.js
+++ b/packages/handler/src/knownContracts/foundation.js
@@ -30,8 +30,6 @@ export default {
     const metadataRes = await fetch(tokenURI.value)
     const metadata = await metadataRes.json()
 
-    console.log(metadata)
-
     const mediaUrl = isIPFS(metadata?.image)
       ? makeIPFSUrl(metadata?.image, "https://ipfs.foundation.app/ipfs/")
       : metadata?.image

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nfte/react",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "description": "A React component for rendering NFT's in your app",
   "source": "src/index.ts",
   "main": "dist/react.js",

--- a/packages/react/src/contracts.ts
+++ b/packages/react/src/contracts.ts
@@ -1,0 +1,7 @@
+export default {
+  foundation: "0x3b3ee1931dc30c1957379fac9aba94d1c48a5405",
+  superrare: "0xb932a70a57673d89f4acffbe830e8ed7f75fb9e0",
+  ethblockart: "0xb80fbf6cdb49c33dc6ae4ca11af8ac47b0b4c0f3",
+  zora: "0xabefbc9fd2f806065b4f3c237d4b59d9a97bcac7",
+  rarible: "0x60f80121c31a0d46b5279700f9df786054aa5ee5",
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,5 @@
 import { NFTE, css } from "./components/NFTE"
 import Embed from "./components/Embed"
+import contracts from "./contracts"
 
-export { NFTE, Embed, css }
+export { NFTE, Embed, css, contracts }

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nfte/site",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": true,
   "license": "MIT",
   "author": "Sam Mason de Caires <sam.jbmason@gmail.com>",
@@ -10,8 +10,8 @@
     "dev": "next dev"
   },
   "dependencies": {
-    "@nfte/handler": "^1.0.2",
-    "@nfte/react": "^1.0.1",
+    "@nfte/handler": "^1.0.3",
+    "@nfte/react": "^1.0.3",
     "@stitches/react": "^0.0.2",
     "date-fns": "^2.17.0",
     "date-fns-tz": "^1.1.1",

--- a/packages/site/utils/previewNFTs.js
+++ b/packages/site/utils/previewNFTs.js
@@ -1,34 +1,30 @@
-const CONTRACTS = {
-  FOUNDATION: "0x3b3ee1931dc30c1957379fac9aba94d1c48a5405",
-  SUPERRARE: "0xb932a70a57673d89f4acffbe830e8ed7f75fb9e0",
-  ETHBLOCKART: "0xb80fbf6cdb49c33dc6ae4ca11af8ac47b0b4c0f3",
-  ZORA: "0xabefbc9fd2f806065b4f3c237d4b59d9a97bcac7",
-  RARIBLE: "0x60f80121c31a0d46b5279700f9df786054aa5ee5",
-}
+import { contracts } from "@nfte/react"
 
 export default [
   // Arc4G (SuperRare)
-  { contract: CONTRACTS.SUPERRARE, tokenId: "18552" },
+  { contract: contracts.superrare, tokenId: "18552" },
   // Jeff Kraus (Foundation)
-  { contract: CONTRACTS.FOUNDATION, tokenId: "15" },
+  { contract: contracts.foundation, tokenId: "15" },
   // Sam Mason de Caires (Foundation)
-  { contract: CONTRACTS.FOUNDATION, tokenId: "214" },
+  { contract: contracts.foundation, tokenId: "214" },
   // EthBlock.art
-  { contract: CONTRACTS.ETHBLOCKART, tokenId: "149" },
+  { contract: contracts.ethblockart, tokenId: "149" },
   // Zora
-  { contract: CONTRACTS.ZORA, tokenId: "0" },
+  { contract: contracts.zora, tokenId: "0" },
   // James Owen (SuperRare)
-  { contract: CONTRACTS.SUPERRARE, tokenId: "17158" },
+  { contract: contracts.superrare, tokenId: "17158" },
   // Mr.J (Rarible)
-  { contract: CONTRACTS.RARIBLE, tokenId: "78177" },
+  { contract: contracts.rarible, tokenId: "78177" },
   // Audio Ameer Suhayb Carter (Zora)
-  { contract: CONTRACTS.ZORA, tokenId: "178" },
+  { contract: contracts.zora, tokenId: "178" },
   // Audio Ameer Suhayb Carter (Zora)
-  { contract: CONTRACTS.ZORA, tokenId: "178" },
+  { contract: contracts.zora, tokenId: "178" },
   // David Porte Beckfield (Foundation)
-  { contract: CONTRACTS.FOUNDATION, tokenId: "45" },
+  { contract: contracts.foundation, tokenId: "45" },
   // Sean Williams (Foundation)
-  { contract: CONTRACTS.FOUNDATION, tokenId: "301" },
+  { contract: contracts.foundation, tokenId: "301" },
   // Danny Jones (Foundation)
-  { contract: CONTRACTS.FOUNDATION, tokenId: "387" },
+  { contract: contracts.foundation, tokenId: "387" },
+  // Ryan Putname (Foundation)
+  { contract: contracts.foundation, tokenId: "467" },
 ]


### PR DESCRIPTION
**@nfte/react**
- `contracts` is now an export that contains commonly used platform contract addresses